### PR TITLE
use `meow` and massively simplify the code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,14 +1,14 @@
 root = true
 
 [*]
-indent_style = tab
+indent_style = space
+indent_size = 4
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
 [package.json]
-indent_style = space
 indent_size = 2
 
 [*.md]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-a11y
-===================
+# a11y
 
 [![Build Status](http://img.shields.io/travis/addyosmani/a11y/master.svg?style=flat)](https://travis-ci.org/addyosmani/a11y?style=flat) ![](http://img.shields.io/badge/unicorn-approved-ff69b4.svg?style=flat)
 
-Easy accessibility audits powered by the Chrome Accessibility Tools.
+> Easy accessibility audits powered by the Chrome Accessibility Tools.
 
 ![](http://i.imgur.com/4jHgzDL.png)
 
@@ -39,7 +38,7 @@ $ a11y --help
 Verbose mode:
 
 ```sh
-$ a11y <url> -f
+$ a11y <url> --verbose
 ```
 
 
@@ -48,7 +47,7 @@ $ a11y <url> -f
 ```js
 var a11y = require('a11y');
 
-a11y({ url: 'http://twitter.com' }, function (err, reports) {
+a11y('http://twitter.com', function (err, reports) {
     var output = JSON.parse(reports);
     var audit = output.audit; // a11y Formatted report
     var report = output.report; // DevTools Accessibility Audit formatted report

--- a/audits.js
+++ b/audits.js
@@ -72,12 +72,12 @@ function auditHandler( status ) {
         console.log( 'Unable to load ' + url + ' successfully' );
         phantom.exit( 1 );
     }
-};
+}
 
 // Validate input and open page for auditing
-if ( system.args.length !== 2 ) {
-    console.log( 'Please pass a valid URL for auditing' );
-    phantom.exit( 1 );
+if (system.args.length !== 2) {
+    console.log('Please pass a valid URL for auditing');
+    phantom.exit(1);
 } else {
     var url = system.args[1];
     webpage.open( url, auditHandler );

--- a/cli.js
+++ b/cli.js
@@ -1,91 +1,45 @@
 #!/usr/bin/env node
 'use strict';
-/**
- * Binary will be available by executing `npm install a11y -g`
- */
-
-// Awesome internal and external libs
-var a11y    = require('./');
-var axs     = require('accessibility-developer-tools/dist/js/axs_testing.js');
-var pkg     = require('./package.json');
-var argv    = require('minimist')((process.argv.slice(2)));
-var chalk   = require('chalk');
 var logSymbols = require('log-symbols');
-var query   = process.argv[2];
-var opts = {};
+var meow = require('meow');
+var a11y = require('./');
 
-process.title = 'a11y';
+var cli = meow({
+    help: [
+        'Usage',
+        '  a11y <url>',
+        '',
+        'Options',
+        '  --verbose    Displays more information'
+    ].join('\n')
+});
 
-/**
- * Display CLI help
- */
-function printHelp() {
-    console.log(pkg.description);
-    console.log('');
-    console.log('Usage:');
-    console.log('  $ a11y <url>');
-    console.log('');
-    console.log('Verbose mode:')
-    console.log('  $ a11y <url> -f');
-}
-
-// Display package version
-if ( process.argv.indexOf('-v') !== -1 || process.argv.indexOf('--version') !== -1 ) {
-    console.log(pkg.version);
-    return;
-}
-
-// Display complete output
-if ( process.argv.indexOf('-f') !== -1 || process.argv.indexOf('--full') !== -1 ) {
-    opts.verbose = true;
-}
-
-if( argv.url ){
-    opts.url = argv.url;
-}
-
-if ( query.indexOf('http') !== -1 ) {
-    opts.url = argv._[0];
-}
-
-// Display help if no valid URL supplied
-if( !opts.url ){
-    printHelp();
-    return;
-}
-
-a11y( opts, function ( err, reports ) {
-    if ( err ) {
-        console.error( err.message );
-        process.exit( err.errcode );
-    } else {
-        if ( opts.verbose === true ) {
-            console.log( JSON.parse(reports) );
-        } else {
-            var output = JSON.parse( reports);
-            var audit = output.audit;
-            var report = output.report;
-            var passes   = "";
-            var failures = "";
-
-            audit.forEach(function( report ){
-                var entry = report;
-
-                if ( entry.result === 'PASS' ) {
-                    passes += chalk.green( logSymbols.success + ' ' + entry.heading + '\n' );
-                }
-
-                if ( entry.result === 'FAIL' ) {
-                    failures += chalk.red( logSymbols.error + ' ' + entry.heading + '\n' );
-                    failures += entry.elements + '\n\n';
-                }
-
-            });
-
-            console.log( failures );
-            console.log( passes );
-
-        }
+a11y(cli.input[0], cli.flags, function (err, reports) {
+    if (err) {
+        console.error(err.message);
+        process.exit(err.code || 1);
+        return;
     }
 
+    if (cli.flags.verbose === true) {
+        console.log(reports);
+    } else {
+        var passes = '';
+        var failures = '';
+
+        reports.audit.forEach(function (el) {
+            if (el.result === 'PASS') {
+                passes += logSymbols.success + ' ' + el.heading + '\n';
+            }
+
+            if (el.result === 'FAIL') {
+                failures += logSymbols.error + ' ' + el.heading + '\n';
+                failures += el.elements + '\n\n';
+            }
+
+        });
+
+        console.log(failures);
+        console.log(passes);
+    }
 });

--- a/index.js
+++ b/index.js
@@ -1,47 +1,25 @@
-/**
- * Wrapper for working with PhantomJS
- */
-
+'use strict';
 var path = require('path');
 var phantomjs = require('phantomjs');
-var binaryPath = phantomjs.path;
-var spawnprocess = require('child_process').spawn;
-var AUDITS_SCRIPT = path.join( __dirname, 'audits.js' );
+var execFile = require('child_process').execFile;
 
-module.exports = function ( opts, cb ) {
-    var argsForScript = [opts.url];
-    var subArgs = ['--ignore-ssl-errors=true', '--ssl-protocol=tlsv1', AUDITS_SCRIPT].concat(argsForScript);
-    var out = "";
-    var err = "";
-    var cp;
+module.exports = function (url, opts, cb) {
+    if (typeof opts !== 'object') {
+        cb = opts;
+        opts = {};
+    }
 
-    cp = spawnprocess( binaryPath, subArgs );
-
-    cp.on( 'error' , function( err ) {
-        console.error( 'Error:', binaryPath, err.stack );
-        cb( err );
-    });
-
-    cp.stdout.on( 'data' , function( data ) {
-        out += data;
-    });
-
-    cp.stderr.on( 'data', function( data ) {
-        err += data;
-    });
-
-    cp.on( 'close' , function( errCode ) {
-        if ( errCode !== 0 ) {
-            console.log( 'Process closed with code' + errCode );
+    execFile(phantomjs.path, [
+        '--ignore-ssl-errors=true',
+        '--ssl-protocol=tlsv1',
+        path.join(__dirname, 'audits.js'),
+        url
+    ], function (err, stdout) {
+        if (err) {
+            cb(err);
+            return;
         }
-    });
 
-    cp.on( 'exit' , function( errCode ) {
-        if ( errCode === 0 ) {
-            cb( null , out );
-        } else {
-            console.error( 'PhantomJS process exited with code ' + errCode );
-            cb({ code: errCode, message: err });
-        }
+        cb(null, JSON.parse(stdout));
     });
 };

--- a/package.json
+++ b/package.json
@@ -28,10 +28,8 @@
   ],
   "dependencies": {
     "accessibility-developer-tools": "git://github.com/GoogleChrome/accessibility-developer-tools",
-    "chalk": "^0.5.1",
     "log-symbols": "^1.0.1",
-    "minimist": "^1.1.0",
-    "nopt": "^3.0.1",
+    "meow": "^1.0.0",
     "phantomjs": "^1.9.10"
   },
   "devDependencies": {}


### PR DESCRIPTION
The code is a lot simpler and consistent now.

Also took the liberty to improve the API. The first argument is now the url, second is options (none yet, but having it there for future ones).

Handle JSON parsing in the API.

Verbose mode is using the `--verbose` flag instead of `--full`. More common.

Use `execFile` to simplify child process code.

Now only color the pass/fail symbols and not the next. IMHO looks better as coloring everything makes it too noisy:

![screen shot 2014-10-14 at 11 59 43](https://cloud.githubusercontent.com/assets/170270/4627213/dae7e98c-5388-11e4-9c36-293af4690436.png)
## 

Next I'm going to simplify the `audit.js` code.
