### PR TITLE
add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node
+
+RUN npm install -g a11y
+
+ENTRYPOINT ["a11y"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ $ npm install -g a11y
 
 *PhantomJS, which is used for generating the screenshots, is installed automagically, but in some [rare cases](https://github.com/Obvious/phantomjs/issues/102) it might fail to and you'll get an `Error: spawn EACCES` error. [Download](http://phantomjs.org/download.html) PhantomJS manually and reinstall `a11y` if that happens.*
 
+### Using Docker Image
+
+Or if you have docker installed, just run:
+
+```sh
+$ docker run -it --rm addyosmani/a11y <args>
+```
 
 ## CLI usage
 
@@ -108,4 +115,4 @@ constants:
 
 ## License
 
-Apache-2. 
+Apache-2.


### PR DESCRIPTION
I have added support in the documentation for how to run `a11y` in a docker container. I have also added a `Dockerfile`, so that you can set up Automated Docker builds, for the repository.

For it to create a docker build of the server, on every git push, you would need to set up an account on the docker registry and [add this repo to build](https://registry.hub.docker.com/builds/github/addyosmani/a11y) `addyosmani/a11yr`. 

It should pull from the master branch.

How does that sound?
