### PR TITLE
drop `Report for` prefix from CLI header

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -50,7 +50,7 @@ eachAsync(urls, function (url, i, next) {
       var passes = '';
       var failures = '';
 
-      console.log(chalk.underline(chalk.cyan('\nReport for ' + url.replace(/^http:\/\//, '') + '\n')));
+      console.log(chalk.underline(chalk.cyan('\n' + url.replace(/^http:\/\//, '') + '\n')));
 
       reports.audit.forEach(function (el) {
           if (el.result === 'PASS') {


### PR DESCRIPTION
IMHO the url is enough of a header.

Maybe we should also only show the header when there are multiple URLs?

![screen shot 2014-12-23 at 01 03 06](https://cloud.githubusercontent.com/assets/170270/5528851/7a9915b8-8a3f-11e4-98ac-aafa27121199.png)
