### PR TITLE
Add ability to resolve paths with glob

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ a11y localhost:9000
 and local files:
 
 ```sh
-$ a11y index.html web/**/*.html
+$ a11y index.html
 ```
 
 ![](http://i.imgur.com/Ffkrr9D.png)

--- a/README.md
+++ b/README.md
@@ -41,13 +41,19 @@ Also works fine against localhost:
 $ a11y localhost:9000
 ```
 
-and local files, with [glob](https://github.com/isaacs/node-glob#glob) patterns:
+and local files:
 
 ```sh
 $ a11y index.html web/**/*.html
 ```
 
 ![](http://i.imgur.com/Ffkrr9D.png)
+
+even with [glob](https://github.com/isaacs/node-glob#glob) patterns:
+
+```sh
+$ a11y **/*.html
+```
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Also works fine against localhost:
 $ a11y localhost:9000
 ```
 
-and local files:
+and local files, with [glob](https://github.com/isaacs/node-glob#glob) patterns:
 
 ```sh
-$ a11y index.html
+$ a11y index.html web/**/*.html
 ```
 
 ![](http://i.imgur.com/Ffkrr9D.png)

--- a/cli.js
+++ b/cli.js
@@ -6,7 +6,7 @@ var updateNotifier = require('update-notifier');
 var chalk = require('chalk');
 var eachAsync = require('each-async');
 var indentString = require('indent-string');
-var arrayUniq = require('array-uniq');
+var globby = require('globby');
 var protocolify = require('protocolify');
 var humanizeUrl = require('humanize-url');
 var a11y = require('./');
@@ -35,9 +35,11 @@ if (cli.input.length === 0) {
     process.exit(1);
 }
 
-var urls = arrayUniq(cli.input.map(function (el) {
-    return protocolify(el);
-}));
+// Parse the CLI input into valid paths using glob and protocolify.
+var urls = globby.sync(cli.input, {
+  // Ensure not-found paths (like "google.com"), are returned.
+  nonull: true
+}).map(protocolify);
 
 eachAsync(urls, function (url, i, next) {
   a11y(url, cli.flags, function (err, reports) {

--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
   ],
   "dependencies": {
     "accessibility-developer-tools": "^2.6.0",
-    "array-uniq": "^1.0.2",
     "chalk": "^1.0.0",
     "each-async": "^1.1.0",
+    "globby": "^1.2.0",
     "humanize-url": "^1.0.0",
     "indent-string": "^1.2.0",
     "log-symbols": "^1.0.1",


### PR DESCRIPTION
This pull request adds support for [globby](https://github.com/sindresorhus/globby), allowing for CLI input of [glob](https://github.com/isaacs/node-glob)-ed paths.

```
a11y **/*.html google.com
```