### PR TITLE
Remove limit of 5 violations listed per rule

### DIFF
--- a/audits.js
+++ b/audits.js
@@ -53,9 +53,7 @@ webpage.open(opts.url, function (status) {
                 var message = '';
 
                 if (DOMElements !== undefined) {
-                    var maxElements = Math.min(DOMElements.length, 5);
-
-                    for (var i = 0; i < maxElements; i++) {
+                    for (var i = 0; i < DOMElements.length; i++) {
                         var el = DOMElements[i];
                         message += '\n';
                         // Get query selector not browser independent. catch any errors and

--- a/test/test.js
+++ b/test/test.js
@@ -6,6 +6,13 @@ var a11y = require('../');
 
 process.chdir(__dirname);
 
+
+function auditsWithHeader(reports, header) {
+    return reports.audit.filter(function(aud) {
+        return aud.heading === header;
+    });
+};
+
 test('test that an empty URL fails', function (t) {
     t.plan(1);
     try {
@@ -27,24 +34,27 @@ test('fail if no callback is supplied', function (t) {
 test('test local input generates a report if callback is second param', function (t) {
     t.plan(2);
     a11y('fixture.html', function (err, reports) {
-        t.assert(reports.audit[1].heading === 'ARIA state and property values must be valid');
-        t.assert(reports.audit[1].result === 'FAIL');
+        var ariaReports = auditsWithHeader(reports ,'ARIA state and property values must be valid');
+        t.assert(ariaReports.length === 1);
+        t.assert(ariaReports[0] && ariaReports[0].result === 'FAIL');
     });
 });
 
 test('test local input generates a report if callback is third param', function (t) {
     t.plan(2);
     a11y('fixture.html', null, function (err, reports) {
-        t.assert(reports.audit[1].heading === 'ARIA state and property values must be valid');
-        t.assert(reports.audit[1].result === 'FAIL');
+        var ariaReports = auditsWithHeader(reports, 'ARIA state and property values must be valid');
+        t.assert(ariaReports.length === 1);
+        t.assert(ariaReports[0] && ariaReports[0].result === 'FAIL');
     });
 });
 
 test('test local input generates a report requiring a delay', function (t) {
     t.plan(2);
     a11y('fixture.html', {delay: 5} , function (err, reports) {
-        t.assert(reports.audit[8].heading === 'role=main should only appear on significant elements');
-        t.assert(reports.audit[8].result === 'FAIL');
+        var delayReports = auditsWithHeader(reports, 'role=main should only appear on significant elements');
+        t.assert(delayReports.length === 1);
+        t.assert(delayReports[0] && delayReports[0].result === 'FAIL');
     });
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -65,3 +65,11 @@ test('test local input generates a verbose report', function (t) {
     });
 });
 
+test('test local input generates a report that includes all failures for a given violation', function (t) {
+    t.plan(2);
+    a11y('fixture.html', function (err, reports) {
+        var matchingReports = auditsWithHeader(reports, 'This element has an unsupported ARIA attribute');
+        t.assert(matchingReports.length === 1);
+        t.assert(matchingReports[0] && matchingReports[0].elements.match(/\n/g).length === 6);
+    });
+});


### PR DESCRIPTION
It was also necessary to modify the existing tests to pass on our local environment. The tests assumed a specific order of results that was not the case on our machine, so we removed the order dependency.

This resolves issue #41.