### PR TITLE
Fix error handling in audits.js

### DIFF
--- a/audits.js
+++ b/audits.js
@@ -26,7 +26,7 @@ webpage.viewportSize = {
 };
 
 webpage.onResourceTimeout = function (err) {
-    console.log('Error code:' + err.errorCode + ' ' + err.errorString + ' for ' + err.url);
+    console.error('Error code:' + err.errorCode + ' ' + err.errorString + ' for ' + err.url);
     phantom.exit(1);
 };
 
@@ -37,7 +37,7 @@ webpage.onError = opts.verbose ? function (err, trace) {
 
 webpage.open(opts.url, function (status) {
     if (status === 'fail') {
-        console.error('Couldn\'t load url: ' + url);
+        console.error('Couldn\'t load url: '  + opts.url);
         phantom.exit(1);
     }
 
@@ -82,7 +82,7 @@ webpage.open(opts.url, function (status) {
         });
 
         if (!ret) {
-            system.stderr.writeLine('Audit failed');
+            console.error('Audit failed');
             phantom.exit(1);
             return;
         }


### PR DESCRIPTION
- All non-audit output goes to stderr
- Fix status=fail error handling line

Signed-off-by: Geoff Pleiss <gpleiss@pivotal.io>