### PR TITLE
Polyfill bind before running audits

### DIFF
--- a/audits.js
+++ b/audits.js
@@ -6,6 +6,7 @@ var webpage = require('webpage').create();
 var opts = JSON.parse(system.args[1]);
 var PAGE_TIMEOUT = 9000;
 var TOOLS_PATH = 'node_modules/accessibility-developer-tools/dist/js/axs_testing.js';
+var BIND_POLYFILL_PATH = 'node_modules/phantomjs-polyfill/bind-polyfill.js';
 
 function formatTrace(trace) {
     var src = trace.file || trace.sourceURL;
@@ -16,6 +17,11 @@ function formatTrace(trace) {
 // console.error is broken in PhantomJS
 console.error = function () {
     system.stderr.writeLine([].slice.call(arguments).join(' '));
+};
+
+// Need to polyfill bind...
+webpage.onInitialized = function () {
+  webpage.injectJs(BIND_POLYFILL_PATH);
 };
 
 webpage.settings.resourceTimeout = PAGE_TIMEOUT;
@@ -88,7 +94,12 @@ webpage.open(opts.url, function (status) {
         }
 
         console.log(JSON.stringify(ret));
-        phantom.exit();
+        // Must do crazy song and dance to get phantom to exit properly
+        // https://github.com/ariya/phantomjs/issues/12697
+        webpage.close();
+        setTimeout(function() {
+            phantom.exit();
+        }, 0);
     }, opts.delay * 1000);
 
 });

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "meow": "^3.3.0",
     "object-assign": "^3.0.0",
     "phantomjs": "^1.9.10",
+    "phantomjs-polyfill": "0.0.1",
     "protocolify": "^1.0.0",
     "update-notifier": "^0.5.0"
   },


### PR DESCRIPTION
This resolves issues in #44 

We found that polyfilling `bind` made the audit work on all pages with React components. This PR includes the polyfill before opening the to-be-audited page.