### PR TITLE
When ADT 2.9.0 is released, tests don't fail!

### DIFF
--- a/test/fixture.html
+++ b/test/fixture.html
@@ -64,6 +64,12 @@
          id="deceptive-aria">An ARIA button
     </div>
     <img src="./images/button.png" id="deceptive-img"></img>
+    <img src="./images/button.png" id="deceptive-img"></img>
+    <img src="./images/button.png" id="deceptive-img"></img>
+    <img src="./images/button.png" id="deceptive-img"></img>
+    <img src="./images/button.png" id="deceptive-img"></img>
+    <img src="./images/button.png" id="deceptive-img"></img>
+    <img src="./images/button.png" id="deceptive-img"></img>
     <script>
         document.getElementById("deceptive").addEventListener("click", function () {
             alert("I'm not actually a button");

--- a/test/test.js
+++ b/test/test.js
@@ -71,8 +71,8 @@ test('test local input generates a report that includes all failures for a given
 
     a11y('fixture.html', function (err, reports) {
         t.error(err);
-        var matchingReports = auditsWithHeader(reports, 'This element has an unsupported ARIA attribute');
+        var matchingReports = auditsWithHeader(reports, 'Images should have a text alternative or presentational role');
         t.is(matchingReports.length, 1);
-        t.is(matchingReports[0] && matchingReports[0].elements.match(/\n/g).length, 6);
+        t.is(matchingReports[0] && matchingReports[0].elements.match(/\n/g).length, 7);
     });
 });


### PR DESCRIPTION
There is a test that shows that more than 5 elements are shown in a
failure report. The particular failures that were used for this test
were actually false positives that were fixed in ADT 2.9.0-rc.0. So we
rewrote that test to use a real failure.