### PR TITLE
Non zero exit code upon failure(s).

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -68,6 +68,7 @@ eachAsync(urls, function (url, i, next) {
             }
 
             if (el.result === 'FAIL') {
+                process.exitCode = 1;
                 failures += logSymbols.error + ' ' + el.heading + '\n';
                 failures += el.elements + '\n\n';
             }


### PR DESCRIPTION
Exit with a non-zero exit code if any failures are detected. This is useful if using a11y in a CI environment.