### PR TITLE
Update deprecated phantomjs to phantomjs-prebuilt

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 var path = require('path');
 var execFile = require('child_process').execFile;
-var phantomjs = require('phantomjs');
+var phantomjs = require('phantomjs-prebuilt');
 var objectAssign = require('object-assign');
 var protocolify = require('protocolify');
 var parseJson = require('parse-json');

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "meow": "^3.3.0",
     "object-assign": "^4.0.1",
     "parse-json": "^2.1.0",
-    "phantomjs": "^2.1.3",
+    "phantomjs-prebuilt": "^2.1.3",
     "phantomjs-polyfill": "0.0.2",
     "protocolify": "^1.0.0",
     "update-notifier": "^0.6.0"


### PR DESCRIPTION
Tiny PR to replace the deprecated [phantomjs](https://www.npmjs.com/package/phantomjs) package with [phantomjs-prebuilt](https://www.npmjs.com/package/phantomjs-prebuilt).