### PR TITLE
Update to phantomjs-prebuild as per upstream warning

### DIFF
--- a/audits.js
+++ b/audits.js
@@ -7,6 +7,7 @@
  */
 var system = require('system');
 var webpage = require('webpage').create();
+
 var opts = JSON.parse(system.args[1]);
 var PAGE_TIMEOUT = 9000;
 var TOOLS_PATH = 'node_modules/accessibility-developer-tools/dist/js/axs_testing.js';

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 var path = require('path');
 var execFile = require('child_process').execFile;
-var phantomjs = require('phantomjs');
+var phantomjs = require('phantomjs-prebuilt');
 var objectAssign = require('object-assign');
 var protocolify = require('protocolify');
 var parseJson = require('parse-json');

--- a/package.json
+++ b/package.json
@@ -56,10 +56,12 @@
     "meow": "^3.3.0",
     "object-assign": "^4.0.1",
     "parse-json": "^2.1.0",
-    "phantomjs-prebuilt": "^2.1.12",
     "phantomjs-polyfill": "0.0.2",
+    "phantomjs-prebuilt": "^2.1.12",
     "protocolify": "^1.0.0",
-    "update-notifier": "^0.6.0"
+    "system": "^1.0.6",
+    "update-notifier": "^0.6.0",
+    "webpage": "^0.3.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "meow": "^3.3.0",
     "object-assign": "^4.0.1",
     "parse-json": "^2.1.0",
-    "phantomjs": "^2.1.3",
+    "phantomjs-prebuilt": "^2.1.12",
     "phantomjs-polyfill": "0.0.2",
     "protocolify": "^1.0.0",
     "update-notifier": "^0.6.0"


### PR DESCRIPTION
Builds are currently warning that phantomjs-prebuild should be used instead of phantomjs. This PR implements that.