### PR TITLE
Use require.resolve to locate node_module content

### DIFF
--- a/audits.js
+++ b/audits.js
@@ -10,8 +10,8 @@ var webpage = require('webpage').create();
 
 var opts = JSON.parse(system.args[1]);
 var PAGE_TIMEOUT = 9000;
-var TOOLS_PATH = 'node_modules/accessibility-developer-tools/dist/js/axs_testing.js';
-var BIND_POLYFILL_PATH = 'node_modules/phantomjs-polyfill/bind-polyfill.js';
+var TOOLS_PATH = opts.toolsPath;
+var BIND_POLYFILL_PATH = opts.bindPolyfillPath;
 
 function formatTrace(trace) {
     var src = trace.file || trace.sourceURL;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 'use strict';
-const path = require('path');
 const execFile = require('child_process').execFile;
 const phantomjs = require('phantomjs-prebuilt');
 const protocolify = require('protocolify');
@@ -25,13 +24,17 @@ module.exports = (url, opts, cb) => {
     delete opts.viewportSize;
 
     opts = Object.assign({delay: 1}, opts, {
+        // Use require.resolve to avoid making assumptions about path locations for node_modules
+        toolsPath: require.resolve('accessibility-developer-tools/dist/js/axs_testing'),
+        bindPolyfillPath: require.resolve('phantomjs-polyfill/bind-polyfill'),
+
         url: protocolify(url),
         width: viewportSize[0] || 1024,
         height: viewportSize[1] || 768
     });
 
     execFile(phantomjs.path, [
-        path.join(__dirname, 'audits.js'),
+        require.resolve('./audits'),
         JSON.stringify(opts),
         '--ignore-ssl-errors=true',
         '--ssl-protocol=tlsv1',


### PR DESCRIPTION
This allows for a11y to execute from directories other than the `pwd`/node_modules/a11y, supporting npm link and the parent node_modules Docker install patterns.